### PR TITLE
Fix heredoc syntax in build helper

### DIFF
--- a/build_suckless.sh
+++ b/build_suckless.sh
@@ -220,7 +220,8 @@ ensure_multilib_repo_enabled() {
   require_command python3 "Python 3 is needed to update $pacman_conf."
 
   echo "Enabling pacman multilib repository in $pacman_conf."
-  if run_with_privilege python3 - "$pacman_conf" <<'PY'; then
+  if run_with_privilege python3 - "$pacman_conf" <<'PY'
+  then
 import sys
 
 path = sys.argv[1]


### PR DESCRIPTION
## Summary
- fix the heredoc-based python helper invocation so that `bash -n` parsing succeeds

## Testing
- bash -n build_suckless.sh

------
https://chatgpt.com/codex/tasks/task_b_68cc5b79b2ac832f9d6505adb2700901