### PR TITLE
Fix multilib heredoc syntax

### DIFF
--- a/build_suckless.sh
+++ b/build_suckless.sh
@@ -221,7 +221,6 @@ ensure_multilib_repo_enabled() {
 
   echo "Enabling pacman multilib repository in $pacman_conf."
   if run_with_privilege python3 - "$pacman_conf" <<'PY'
-  then
 import sys
 
 path = sys.argv[1]


### PR DESCRIPTION
## Summary
- remove the stray `then` from the heredoc in `ensure_multilib_repo_enabled` so only Python remains within it

## Testing
- `bash -n build_suckless.sh`


------
https://chatgpt.com/codex/tasks/task_b_68cc60e829b4832fac8da61bad631709